### PR TITLE
Fix memory leak in Index getitem

### DIFF
--- a/litecoder/usa.py
+++ b/litecoder/usa.py
@@ -212,8 +212,11 @@ class Index:
         )
 
     def __getitem__(self, text):
-        """Get ids, map to records.
+        """Get ids, map to records only if there is a match in the index
         """
+        if keyify(text) not in self._key_to_ids:
+            return None
+
         ids = self._key_to_ids[keyify(text)]
 
         return [self._id_to_loc[id] for id in ids]


### PR DESCRIPTION
`_key_to_ids` is a defaultdict(set) so it creates a set for every new key that it sees. This becomes a problem if we feed it enough keys (e.g many account bios from the decahose) because it'll consume all available memory.

I added a basic check if the key exists in `_key_to_ids`, and only create `ids` if it exists. 