### PR TITLE
Fix yaml.load() deprecation

### DIFF
--- a/litecoder/models/wof_locality.py
+++ b/litecoder/models/wof_locality.py
@@ -22,7 +22,7 @@ from .base import BaseModel
 # TODO: Make pluggable.
 CITY_ALT_NAMES = yaml.load(pkgutil.get_data(
     'litecoder', 'data/city-alt-names.yml'
-))
+), Loader=yaml.FullLoader)
 
 
 ID_COLS = (

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,4 +16,4 @@ def read_yaml(from_path, file_name):
     path = os.path.join(os.path.dirname(from_path), file_name)
 
     with open(path, 'r') as fh:
-        return yaml.load(fh)
+        return yaml.load(fh, Loader=yaml.FullLoader)


### PR DESCRIPTION
Fixes yaml.load() deprecation.

```
~/litecoder/litecoder/models/wof_locality.py:23: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
```

https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation